### PR TITLE
added .pm extension

### DIFF
--- a/stylesheets/file-icons.less
+++ b/stylesheets/file-icons.less
@@ -80,6 +80,7 @@
 
   // Perl icon
   &[data-name$=".pl"]:before { .perl-icon; .medium-purple; }
+  &[data-name$=".pm"]:before { .perl-icon; .medium-purple; }
 
   // Java icon
   &[data-name$=".java"]:before { .java-icon; .medium-purple; }


### PR DESCRIPTION
Perl projects primarily use the ".pm" extension, which stands for "Perl Module".
