### PR TITLE
made npm icon medium

### DIFF
--- a/stylesheets/icons.less
+++ b/stylesheets/icons.less
@@ -53,5 +53,5 @@
 .grunt-icon         { .icomoon; content: "\e611"; top: 3px; }
 .gulp-icon          { .icomoon; content: "\e610"; top: 2px; }
 .hbs-mustache-icon  { .icomoon; content: "\e60f"; top: 3px; }
-.npm-icon           { .icomoon; content: "\e616"; top: 4px; }
+.npm-icon           { .icomoon; content: "\e616"; top: 4px; font-size: medium; }
 .sass-icon          { .icomoon; content: "\e603"; top: 3px; }


### PR DESCRIPTION
The npm icon as small font is hard to read. Medium would probably be the best size
