### PR TITLE
Update file-icons.less

### DIFF
--- a/stylesheets/file-icons.less
+++ b/stylesheets/file-icons.less
@@ -81,6 +81,8 @@
   // Gear icon
   &[data-name$=".gitignore"]:before     { .gear-icon;                 }
   &[data-name$=".gitattributes"]:before { .gear-icon;                 }
+  &[data-name=".gitmodules"]:before     { .gear-icon;                 }
+  &[data-name=".mailmap"]:before        { .gear-icon;                 }
   &[data-name$=".editorconfig"]:before  { .gear-icon; .medium-orange; }
   &[data-name$=".jshintrc"]:before      { .gear-icon; .medium-yellow; }
   &[data-name$=".jscsrc"]:before        { .gear-icon; .medium-yellow; }
@@ -88,6 +90,7 @@
   &[data-name$=".htaccess"]:before      { .gear-icon; .medium-red;    }
 
   // Npm icon
+  &[data-name=".npmrc"]:before           { .node-icon; }
   &[data-name=".npmignore"]:before       { .node-icon; }
   &[data-name="npm-debug.log"]:before    { .node-icon; .medium-red; }
 


### PR DESCRIPTION
Add Gear icon for the following files:
- .gitmodules
  - Used by Git to store information about git submodules
- .mailmap
  - Used by Git to fix botched-up names and email addresses
  - and makes sure that look nicer when using "git shortlog"
- .npmrc
  - Configuration file that may contains some NPM parameters
