### PR TITLE
font-smoothing for better visualization in mac

### DIFF
--- a/stylesheets/items.less
+++ b/stylesheets/items.less
@@ -4,4 +4,6 @@
 @{pane-tab-selector}:before {
   margin-right: 5px;
   vertical-align: middle;
+  //for better visualization in mac os
+  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
I add this property in my case because the icons were not being displayed in the same form in the sidebar and tabs.
