### PR TITLE
add more markdown types

### DIFF
--- a/stylesheets/file-icons.less
+++ b/stylesheets/file-icons.less
@@ -173,6 +173,12 @@
   &[data-name$=".secret"]:before { .secret-icon; }
 
   // Markdown (except readme.md)
+  &[data-name$=".mdown"]:before,
+  &[data-name$=".markdown"]:before,
+  &[data-name$=".mkd"]:before,
+  &[data-name$=".mkdown"]:before,
+  &[data-name$=".rmd"]:before,
+  &[data-name$=".ron"]:before,
   &[data-name$=".md"]:before  { .markdown-icon; .medium-blue;   }
 
   // txt


### PR DESCRIPTION
As listed in https://github.com/atom/language-gfm/blob/master/grammars/gfm.cson, there are more markdown file types.
