### PR TITLE
added .t extension and changed the Perl color to a more appropriate blue

### DIFF
--- a/stylesheets/file-icons.less
+++ b/stylesheets/file-icons.less
@@ -128,8 +128,9 @@
   &[data-name$=".pp"]:before { .puppet-icon; .medium-purple }
 
   // Perl icon
-  &[data-name$=".pl"]:before { .perl-icon; .medium-purple; }
-  &[data-name$=".pm"]:before { .perl-icon; .medium-purple; }
+  &[data-name$=".pl"]:before { .perl-icon; .medium-blue; }
+  &[data-name$=".pm"]:before { .perl-icon; .medium-blue; }
+  &[data-name$=".t"]:before { .perl-icon; .medium-blue; }
 
   // Java icon
   &[data-name$=".java"]:before { .java-icon; .medium-purple; }


### PR DESCRIPTION
The ".t" extension is commonly used for Perl tests. And if there's an appropriate color for Perl, it would have to be blue, like the popular [O'Reilly books](http://shop.oreilly.com/product/9780596004927.do) or the [official website](http://perl.org).
