### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Troubleshooting
 **An icon has stopped updating:**  
 It's probably a caching issue. Do the following:
 
-1. Open the command palette: <kbd>Cmd/Ctrl + Shift + P</kbd>
+1. Open the command palette: <kbd>Cmd/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>
 2. Run `file-icons:clear-cache`
 3. Reload the window, or restart Atom
 


### PR DESCRIPTION
The `<kbd>` tag was used incorrectly, it's supposed to be around a single key, not a group of keys.