### PR TITLE
Support file extensions for .postcssrc

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -2900,7 +2900,7 @@ fileIcons:
 		match: [
 			[/\.p(ost)?css$/i, "dark-red", "postcss"]
 			[/\.sss$/i, "dark-pink", "sugarss"]
-			[".postcssrc", "auto-orange"]
+			[/\.postcssrc(\.(js|json|ya?ml))?$/i, "auto-orange"]
 			[/\bpostcss\.config\.js$/i, "auto-yellow", priority: 2]
 		]
 


### PR DESCRIPTION
Now it's possible to specify file extensions for `.postcssrc` (same case of `.eslintrc`).

https://github.com/michael-ciniawsky/postcss-load-config/releases/tag/v1.2.0