### PR TITLE
Add `protractor.config.js` to protractor icon matches

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -3079,7 +3079,7 @@ fileIcons:
 	Protractor:
 		icon: "protractor"
 		priority: 2
-		match: /^protractor\.conf\./i
+		match: /^protractor\.(conf|config)\./i
 		colour: "medium-red"
 
 	Pug:


### PR DESCRIPTION
Since `protractor.conf.js` is not strictly required filename, let's also support `protractor.config.js` which is consistent filename when you also have `(webpack|jasmine|postcss).config.js`.

Probably, the same thing could be done to Karma...