### PR TITLE
Support webpack.*.conf.js files

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -4116,7 +4116,7 @@ fileIcons:
 		icon: "webpack"
 		priority: 2
 		match: [
-			[/webpack\.conf(ig)?\./i, "medium-blue"]
+			[/webpack(\.\w+)?\.conf(ig)?\./i, "medium-blue"]
 			[/^webpackfile\.js$/i, "medium-blue"]
 		]
 

--- a/config.cson
+++ b/config.cson
@@ -4116,7 +4116,7 @@ fileIcons:
 		icon: "webpack"
 		priority: 2
 		match: [
-			[/webpack(\.\w+)?\.conf(ig)?\./i, "medium-blue"]
+			[/webpack(\.\w+)*\.conf(ig)?\./i, "medium-blue"]
 			[/^webpackfile\.js$/i, "medium-blue"]
 		]
 


### PR DESCRIPTION
When using [VueJS webpack template](https://github.com/vuejs-templates/webpack), we get several webpack files:
- webpack.base.conf.js
- webpack.dev.conf.js
- webpack.prod.conf.js
- webpack.test.conf.js

with no webpack icon :(

I just updated the webpack regex to `/webpack(\.\w+)?\.conf(ig)?\./i` to match these files

> First PR ever, I hope I did it right :)