### PR TITLE
Support .stylelintcache files

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -3691,7 +3691,7 @@ fileIcons:
 		match: [
 			[/^\.stylelintrc(\.|$)/i, "medium-purple"]
 			[/^stylelint\.config\.js$/i, "auto-yellow"]
-			[".stylelintignore", "dark-blue"]
+			[/\.stylelint(ignore|cache)$/i, "dark-blue"]
 		]
 
 	Stylus:

--- a/lib/icons/.icondb.js
+++ b/lib/icons/.icondb.js
@@ -159,7 +159,7 @@ module.exports = [
 ["sourcemap-icon",["medium-yellow","dark-yellow"],/\.js\.map$/i,2],
 ["stylelint-icon",["medium-purple","medium-purple"],/^\.stylelintrc(?:\.|$)/i,2],
 ["stylelint-icon",["medium-yellow","dark-yellow"],/^stylelint\.config\.js$/i,2],
-["stylelint-icon",["dark-blue","dark-blue"],/\.stylelintignore$/i,2],
+["stylelint-icon",["dark-blue","dark-blue"],/\.stylelint(?:ignore|cache)$/i,2],
 ["swagger-icon",["medium-green","medium-green"],/^swagger\.json$/i,2],
 ["toc-icon",["medium-cyan","dark-cyan"],/\.toc$/i,2,false,,/\.toc$/i,/^Table[\W_ \t]?[0o]f[\W_ \t]?C[0o]ntents$/i],
 ["test-ruby-icon",["medium-red","dark-red"],/([\\\x2F])(test|spec)s?(\1((?!\1).)+)*\1((?!\1).)+[._-](spec|test)s?\.rb$/i,2,true],


### PR DESCRIPTION
[stylelint v7.10.0](https://github.com/stylelint/stylelint/releases/tag/7.10.0) introduced cache functionality, with the filename defaults to `.stylelintcache`. I followed the same idea of `.eslint{ignore,cache}` files.