### PR TITLE
Use npm icon for package-lock.json

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -2768,7 +2768,7 @@ fileIcons:
 	NPM:
 		icon: "npm"
 		priority: 2
-		match: /^(package\.json|\.npmignore|\.?npmrc|npm-debug\.log|npm-shrinkwrap\.json)$/i
+		match: /^(package\.json|\.npmignore|\.?npmrc|npm-debug\.log|npm-shrinkwrap\.json|package-lock\.json)$/i
 		colour: "medium-red"
 
 	NSIS:


### PR DESCRIPTION
Introduced by npm 5: https://github.com/npm/npm/pull/16244