### PR TITLE
Add .min and .bundle support for Chart.js

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -737,7 +737,7 @@ fileIcons:
 	ChartJS:
 		icon: "chartjs"
 		priority: 2
-		match: /^Chart\.js$/i
+		match: /^Chart(\.bundle)?(\.min)?\.js$/i
 		colour: "dark-pink"
 
 	Checklist:


### PR DESCRIPTION
These files are shipped with current Chart.js releases: https://github.com/chartjs/Chart.js/releases