### PR TITLE
Add support for ".docker" directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - **New icons:** Edge (`.edge`), Firebase (`.firebaserc`, `firebase.json`), GLSL (`.glsl`, `.glslv`, `.gsh`, `.gshader`), Vertex/Fragment Shader (`.fp`, `.frag`, `.frg`, `.fsh`, `.fshader`, `.vert`, `.vertex`, `.vrx`, `.vsh`), SketchUp LayOut (`.layout`), SketchUp Make (`.skp`), SketchUp Style Builder (`.style`), WebGL (`.webgl`)
 - **Support:** 3D Asset (`.comp`, `.geo{m,metry}`, `.tesc`, `.tese`), ChartJS (`chart.{bundle,min}.js`), NPM (`package-lock.json`)
+- **Support:** Docker (`.docker` directories)
 
 
 

--- a/config.cson
+++ b/config.cson
@@ -93,10 +93,10 @@ directoryIcons:
 		icon: "circleci"
 		match: /^\.circleci$/
 
-  Docker:
+	Docker:
 		icon: "docker"
-    match: /^\.docker$/
-    colour: "dark-blue"
+		match: /^\.docker$/
+		colour: "dark-blue"
 
 	Dropbox:
 		icon: "dropbox"

--- a/config.cson
+++ b/config.cson
@@ -93,6 +93,11 @@ directoryIcons:
 		icon: "circleci"
 		match: /^\.circleci$/
 
+  Docker:
+		icon: "docker"
+    match: /^\.docker$/
+    colour: "dark-blue"
+
 	Dropbox:
 		icon: "dropbox"
 		match: /^(Dropbox|\.dropbox\.cache)$/

--- a/lib/icons/.icondb.js
+++ b/lib/icons/.icondb.js
@@ -5,6 +5,7 @@ module.exports = [
 ["bower-icon",["medium-yellow","medium-orange"],/^bower[-_]components$/],
 ["chef-icon",[null,null],/\.chef$/],
 ["circleci-icon",[null,null],/^\.circleci$/],
+["docker-icon",["dark-blue","dark-blue"],/^\.docker$/],
 ["dropbox-icon",["medium-blue","medium-blue"],/^(?:Dropbox|\.dropbox\.cache)$/],
 ["emacs-icon",["medium-purple","medium-purple"],/^\.emacs\.d$/],
 ["dylib-icon",[null,null],/\.framework$/i],


### PR DESCRIPTION
I was just browsing my home directory and thought it would be fun to have the `.docker` directory visually show that it has to do with Docker. 🙂