### PR TITLE
Fixed exception in archive consumer.

### DIFF
--- a/lib/consumers/archive-view.js
+++ b/lib/consumers/archive-view.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const pathModule = require("path");
 const {normalisePath} = require("alhadis.utils");
 const ArchiveEntry = require("./archive-entry.js");
 const Consumer = require("./consumer.js");
@@ -125,7 +126,7 @@ class ArchiveView extends Consumer {
 		return elements
 			.reverse()
 			.map(el => el.firstElementChild.textContent)
-			.join("/");
+			.join(pathModule.sep);
 	}
 }
 

--- a/lib/consumers/archive-view.js
+++ b/lib/consumers/archive-view.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const pathModule = require("path");
+const {sep} = require("path");
 const {normalisePath} = require("alhadis.utils");
 const ArchiveEntry = require("./archive-entry.js");
 const Consumer = require("./consumer.js");
@@ -126,7 +126,7 @@ class ArchiveView extends Consumer {
 		return elements
 			.reverse()
 			.map(el => el.firstElementChild.textContent)
-			.join(pathModule.sep);
+			.join(sep);
 	}
 }
 


### PR DESCRIPTION
The package throws exception on Windows when archive-view uses it in archive with nested files/directories.

Not sure if importing `path` is ok here or it should go somewhere in [Atom-FS package](https://github.com/Alhadis/Atom-FS) for abstraction.