### PR TITLE
Update Jest regex

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -2085,7 +2085,7 @@ fileIcons:
 		icon: "jest"
 		priority: 2
 		match: [
-			[/^jest(\.config)?\.json$/i, "medium-red"]
+			[/^jest(\.config)?\.js(on)?$/i, "medium-red"]
 			[/\.jsx?\.snap$/i, "auto-yellow"]
 		]
 


### PR DESCRIPTION
With Jest v20, `jest.config.js` is a valid config file as well. The current regex was only matching on `jest.config.json`.

:+1: for this lib, btw.