### PR TITLE
Fix Imba icon color, implement icon class in icons.less

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -2133,7 +2133,7 @@ fileIcons:
 	Imba:
 		icon: "imba"
 		match: ".imba"
-		colour: "medium-purple"
+		colour: "medium-blue"
 		scope: /\.imba$/
 
 	"Inform 7":

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -392,6 +392,7 @@
 .infopath-icon:before      { .fi; content: "\ea35"; top: 2px; font-size: 16px; }
 .inform7-icon:before       { .fi; content: "\e984"; top: 2px; font-size: 16px; .sharpen; }
 .inno-icon:before          { .fi; content: "\e985"; top: 2px; }
+.imba-icon:before					 { .fi; content: "\e90e"; top: 2px; font-size: 16px; }
 .io-icon:before            { .fi; content: "\e981"; top: 1px; font-size: 13px; .thicken; }
 .ioke-icon:before          { .fi; content: "\e982"; top: 2px; }
 .ionic-icon:before         { .fi; content: "\f14b"; top: 2px; }


### PR DESCRIPTION
I'm not sure why the commit indentation in icons.less is formatted improperly, but with this config.cson color update. and added content charmap I get:

![Example Imba Icon](https://i.imgur.com/GlQ6MlF.png) 