### PR TITLE
Support `appveyor.yml` and `.appveyor.yml`

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -359,7 +359,7 @@ fileIcons:
 	Appveyor:
 		icon: "appveyor"
 		priority: 2
-		match: /^appveyor\.yml$/i
+		match: /^\.?appveyor\.yml$/i
 		colour: "medium-blue"
 
 	Arc:

--- a/lib/icons/.icondb.js
+++ b/lib/icons/.icondb.js
@@ -36,7 +36,7 @@ module.exports = [
 ["apache-icon",["dark-green","dark-green"],/\.vhost$/i,2],
 ["apache-icon",["medium-green","medium-green"],/\.thrift$/i,2],
 ["appcelerator-icon",["medium-red","medium-red"],/^appcelerator\.js$/i,2],
-["appveyor-icon",["medium-blue","medium-blue"],/^appveyor\.yml$/i,2],
+["appveyor-icon",["medium-blue","medium-blue"],/^\.?appveyor\.yml$/i,2],
 ["archlinux-icon",["dark-purple","dark-purple"],/^\.install$/,2],
 ["archlinux-icon",["dark-maroon","dark-maroon"],/^\.SRCINFO$/,2],
 ["archlinux-icon",["dark-yellow","dark-yellow"],/^pacman\.conf$/,2],


### PR DESCRIPTION
Both dotted and non dotted format are valid. Ref: https://www.appveyor.com/docs/build-configuration/#yaml-file-alternative-naming