### PR TITLE
Lazily require the 'micromatch' dependency

### DIFF
--- a/lib/service/strategies/linguist-strategy.js
+++ b/lib/service/strategies/linguist-strategy.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const path = require("path");
-const Micromatch = require("micromatch");
 const {CompositeDisposable, Disposable} = require("atom");
 const {MappedDisposable, PatternMap, PatternSet} = require("alhadis.utils");
 const {FileSystem} = require("atom-fs");
@@ -152,6 +151,9 @@ class LinguistStrategy extends Strategy {
 				// Only acknowledge languages with icons
 				if(!languageIcon)
 					return null;
+
+				// Lazily require the micromatch dependency due to its weight.
+				const Micromatch = require("micromatch");
 				
 				pattern = path.dirname(filePath) + "/" + (/^\//.test(pattern) ? "" : "**") + "/" + pattern;
 				pattern = path.resolve(pattern);


### PR DESCRIPTION
The 'micromatch' dependency seems to be unusually heavy - when using `atom --profile-startup` this seems to account for over 200ms of activation time! It's extremely straightforward to defer its loading until the "linguist" strategy is actually executed.