### PR TITLE
Notify FileSystem on resource deletion

### DIFF
--- a/lib/service/icon-service.js
+++ b/lib/service/icon-service.js
@@ -14,6 +14,16 @@ class IconService{
 	init(paths){
 		this.disposables = new CompositeDisposable();
 		this.disposables.add(FileSystem.observe(this.handleResource.bind(this)));
+
+		// Get notified when a file is deleted and let `FileSystem` know - see #693
+		this.disposables.add(atom.project.onDidChangeFiles(events => {
+			for(const event of events) {
+				if("deleted" === event.action) {
+					const resource = FileSystem.get(event.path);
+					if(resource) resource.destroy();
+				}
+			}
+		}));
 		StrategyManager.init();
 		this.isReady = true;
 	}


### PR DESCRIPTION
The `FileSystem` module wasn't being notified on resource deletion which
resulted in an inconsistent state of the resource cache. By subscribing
to deletion notifications for files in the project and destroying the
resource if it's cached in the `Filesystem` module, we solve that issue.

Fixes #490