### PR TITLE
Add support for .babelrc.js

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -501,7 +501,7 @@ fileIcons:
 	Babel:
 		icon: "babel"
 		match: [
-			[/\.(babelrc|languagebabel|babel)$/i, "medium-yellow"]
+			[/\.(babelrc|babelrc\.js|languagebabel|babel)$/i, "medium-yellow"]
 			[".babelignore", "dark-yellow"]
 		]
 


### PR DESCRIPTION
Babel 7 uses this JavaScript configuration file.