### PR TITLE
Avoid unnecessarily creating resources for deleted files

### DIFF
--- a/lib/service/icon-service.js
+++ b/lib/service/icon-service.js
@@ -17,7 +17,7 @@ class IconService{
 		// Get notified when a file is deleted and let `FileSystem` know - see #693
 		this.disposables.add(atom.project.onDidChangeFiles(events => {
 			for(const event of events) {
-				if("deleted" === event.action) {
+				if("deleted" === event.action && FileSystem.paths.has(event.path)) {
 					const resource = FileSystem.get(event.path);
 					if(resource) resource.destroy();
 				}


### PR DESCRIPTION
When we get a 'deleted' event from `atom.project.onDidChangeFiles` in `IconService`, currently `FileSystem.get` is called - which will create a resource + icon for the file if it hasn't been processed already.

This leads to poor performance when performing e.g. git or hg updates - at least with 'hg' Atom handles Mercurial's atomic file writes as a delete + create, so we end up doing work for every modified file :(

An easy workaround (although it reaches into `FileSystem.paths` is to check `FileSystem.paths.has` before calling `FileSystem.get`.

I manually tested this by linking my local file-icons, running an `hg update`, and verifying that resources weren't created for modified files (despite hitting the 'deleted' case.)