### PR TITLE
Use LRUCache for storage (max: 10000)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,7 @@ module.exports = {
 		IconService.init();
 		require("./debug.js");
 	},
-	
+
 	deactivate(){
 		Storage.lock();
 		IconService.reset();
@@ -27,9 +27,9 @@ module.exports = {
 		Options.reset();
 	},
 
-	serialize(){ return Storage.data; },
+	serialize(){ return Storage.serialize(); },
 
 	provideService(){ return IconService.addIconToElement; },
-	
+
 	suppressFOUC(){ return IconService.suppressFOUC(); }
 };

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,10 +1,12 @@
 "use strict";
 
 const {normalisePath} = require("alhadis.utils");
+const LRUCache = require("lru-cache");
 const {sep} = require("path");
 const isWin = "\\" === sep;
 
-const version = 0x003;
+const MAX_SIZE = 10000;
+const version = 0x004;
 let locked = false;
 let data = null;
 
@@ -15,32 +17,58 @@ let data = null;
  * @class
  */
 class Storage{
-	
+
 	/**
 	 * Initialise session storage.
 	 *
-	 * @param {Object} state - Data serialised from last session
+	 * @param {Object} state - Data serialized from last session
 	 */
 	init(state){
 		locked = false;
-		data = state && state.version === version
-			? state
-			: this.createBlankCache();
-		
+		data = this.deserialize(state);
+
 		this.clean();
 	}
-	
-	
+
+
+	/**
+	 * Returns a serializable version of the data.
+	 */
+	serialize() {
+		if (!data) {
+			return null;
+		}
+		return {
+			paths: data.paths.dump(),
+			version,
+		};
+	}
+
+
+	/**
+	 * Deserializes the result of a previous serialize() call.
+	 */
+	deserialize(state) {
+		if (!state || state.version !== version) {
+			return this.createBlankCache();
+		}
+		const paths = new LRUCache({max: MAX_SIZE});
+		paths.load(state.paths);
+		return {paths, version};
+	}
+
+
 	/**
 	 * Purge cache of invalid or irrelevant data.
 	 */
 	clean(){
-		for(const path in data.paths)
+		data.paths.forEach((value, path) => {
 			if(!this.hasData(path) || !this.isProjectRelated(path))
 				this.deletePath(path);
+		});
 	}
-	
-	
+
+
 	/**
 	 * Create a blank cache to store session data.
 	 *
@@ -48,12 +76,12 @@ class Storage{
 	 */
 	createBlankCache(){
 		return {
-			paths: {},
+			paths: new LRUCache({max: MAX_SIZE}),
 			version
 		};
 	}
-	
-	
+
+
 	/**
 	 * Determine if a currently-open project encloses a path.
 	 *
@@ -63,10 +91,10 @@ class Storage{
 	isProjectRelated(path){
 		for(const root of atom.project.rootDirectories){
 			const projectPath = root.path;
-			
+
 			if(path === projectPath || 0 === path.indexOf(projectPath + sep))
 				return true;
-			
+
 			if(isWin){
 				const fixedPath = normalisePath(projectPath);
 				if(path === fixedPath || 0 === path.indexOf(fixedPath + "/"))
@@ -75,34 +103,35 @@ class Storage{
 		}
 		return false;
 	}
-	
-	
+
+
 	/**
 	 * Use path entries when iterating.
 	 *
 	 * @return {Iterator}
 	 */
 	[Symbol.iterator](){
-		const pathData = this.data.paths;
-		const pathKeys = Object.keys(pathData);
+		const pathData = data.paths;
+		const pathKeys = pathData.keys();
+		const pathValues = pathData.values();
 		const {length} = pathKeys;
 		let index = 0;
-		
+
 		return {
 			next(){
 				if(index >= length)
 					return { done: true };
 				else{
 					const path  = pathKeys[index];
-					const value = [path, pathData[path]];
+					const value = [path, pathValues[index]];
 					++index;
 					return { value };
 				}
 			}
 		};
 	}
-	
-	
+
+
 	/**
 	 * Create a blank entry for an unlisted path.
 	 *
@@ -115,14 +144,16 @@ class Storage{
 	 */
 	addPath(path){
 		if(locked) return;
-		
-		return data.paths[path] = {
+
+		const value = {
 			icon: null,
 			inode: null
 		};
+		data.paths.set(path, value);
+		return value;
 	}
-	
-	
+
+
 	/**
 	 * Retrieve the data cached for a path.
 	 *
@@ -132,15 +163,15 @@ class Storage{
 	 * @return {Object}
 	 */
 	getPathEntry(path){
-		const entry = data.paths[path];
+		const entry = data.paths.get(path);
 		if(entry) return entry;
-		
+
 		return locked
 			? null
 			: this.addPath(path);
 	}
-	
-	
+
+
 	/**
 	 * Retrieve the icon data cached for a path.
 	 *
@@ -150,15 +181,15 @@ class Storage{
 	getPathIcon(path){
 		const {icon} = this.getPathEntry(path);
 		if(!icon) return null;
-		
+
 		return {
 			priority:  icon[0],
 			index:     icon[1],
 			iconClass: icon[2]
 		};
 	}
-	
-	
+
+
 	/**
 	 * Determine if stored data exists for a given path.
 	 *
@@ -166,11 +197,11 @@ class Storage{
 	 * @return {Boolean}
 	 */
 	hasData(path){
-		const entry = data.paths[path] || null;
+		const entry = data.paths.get(path) || null;
 		return !!(entry && (entry.icon || entry.inode));
 	}
-	
-	
+
+
 	/**
 	 * Determine if icon-related data exists for a given path.
 	 *
@@ -178,11 +209,11 @@ class Storage{
 	 * @return {Boolean}
 	 */
 	hasIcon(path){
-		const entry = data.paths[path];
+		const entry = data.paths.get(path);
 		return !!(entry && entry.icon);
 	}
-	
-	
+
+
 	/**
 	 * Store icon-related data for a path.
 	 *
@@ -200,8 +231,8 @@ class Storage{
 			iconData.iconClass
 		];
 	}
-	
-	
+
+
 	/**
 	 * Store the inode of a filesystem path.
 	 *
@@ -211,27 +242,27 @@ class Storage{
 	setPathInode(path, inode){
 		if(!inode || locked) return;
 		let entry = this.getPathEntry(path);
-		
+
 		// We're holding stale data. Shoot it.
 		if(entry.inode && entry.inode !== inode){
 			this.deletePath(path);
 			entry = this.addPath(path);
 		}
-		
+
 		entry.inode = inode;
 	}
-	
-	
+
+
 	/**
 	 * Delete any data being stored for a path.
 	 *
 	 * @param {String} path
 	 */
 	deletePath(path){
-		delete data.paths[path];
+		data.paths.del(path);
 	}
-	
-	
+
+
 	/**
 	 * Delete a path's cached icon.
 	 *
@@ -240,8 +271,8 @@ class Storage{
 	deletePathIcon(path){
 		delete this.getPathEntry(path).icon;
 	}
-	
-	
+
+
 	/**
 	 * Block further changes to cached data.
 	 *
@@ -251,8 +282,8 @@ class Storage{
 	lock(){
 		locked = true;
 	}
-	
-	
+
+
 	/**
 	 * Wipe all cached data.
 	 *
@@ -265,7 +296,7 @@ class Storage{
 			atom.notifications.addError("Storage locked", {detail});
 			return;
 		}
-		
+
 		else{
 			const {size} = this;
 			data = this.createBlankCache();
@@ -275,8 +306,8 @@ class Storage{
 			atom.notifications.addInfo(message, {dismissable: true});
 		}
 	}
-	
-	
+
+
 	/**
 	 * Pointer to the hash which holds all cached data.
 	 *
@@ -286,8 +317,8 @@ class Storage{
 	get data(){
 		return data;
 	}
-	
-	
+
+
 	/**
 	 * Whether the cache has been locked from modification.
 	 *
@@ -297,8 +328,8 @@ class Storage{
 	get locked(){
 		return locked;
 	}
-	
-	
+
+
 	/**
 	 * Number of paths currently cached.
 	 *
@@ -306,7 +337,7 @@ class Storage{
 	 * @readonly
 	 */
 	get size(){
-		return Object.keys(data.paths).length;
+		return data.paths.length;
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -13,18 +13,19 @@
 	},
 	"atomTestRunner": "atom-mocha",
 	"dependencies": {
-		"atom-fs": "v0.1.4",
 		"alhadis.utils": "v0.1.3",
+		"atom-fs": "v0.1.4",
+		"lru-cache": "^4.1.3",
 		"micromatch": "*",
 		"print": ">=v1.1.0"
 	},
 	"devDependencies": {
-		"atom-mocha": ">=v2.0.5",
-		"get-options": "*",
+		"atom-mocha": "^2.0.5",
 		"coffee-script": "*",
+		"get-options": "*",
 		"rimraf": "*",
-		"unzip": "*",
-		"tmp": "*"
+		"tmp": "*",
+		"unzip": "*"
 	},
 	"providedServices": {
 		"file-icons.element-icons": {


### PR DESCRIPTION
This uses https://www.npmjs.com/package/lru-cache to impose an upper bound on the size of storage. I chose 10000 - the storage size is a barely tolerable ~1MB at that point (the overhead of serializing that is about 10ms, which is tolerable I guess. If you're willing to tolerate something lower I think that might be better.)

There's nothing too tricky about this - I searched for all references to `data.paths` and fixed them up appropriately.

- I bumped the version to 4.
- I used "serialize" instead of "serialise" to be consistent with Atom's APIs - let me know if you'd prefer the latter! :P
- My editor stripped out the trailing whitespace - hopefully that's OK.

Testing:

- `atom --dev --test test` is still working fine.
- I restarted Atom and inspected `storage = require(atom.packages.getLoadedPackage('file-icons').path + '/lib/storage')`:
  - It grows correctly as I continue to add icons to it (by expanding stuff in the file tree.)
  - `Array.from(storage)` is working properly.
- Inspected the serialized state via `atom.packages.getLoadedPackage('file-icons').serialize()`.
- Reloaded Atom, and inspected `storage` again to verify that the icons were preserved. There's no flickering as everything can be loaded from cache.

Contributed under CC0. Fixes #661.