### PR TITLE
Add support for `babel.config.js`

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -514,6 +514,7 @@ fileIcons:
 		icon: "babel"
 		match: [
 			[/\.(babelrc|babelrc\.js|languagebabel|babel)$/i, "medium-yellow"]
+			[/babel(\.[\w\-]+)*\.conf(ig)?\./i, "medium-yellow"]
 			[".babelignore", "dark-yellow"]
 		]
 


### PR DESCRIPTION
See also: https://babeljs.io/docs/en/next/babelconfigjs.html. Regex borrowed from Webpack entry.