### PR TITLE
Added icons for rest of Ansible folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Unpublished]
 ----------------------
 ### Added
-- **Support:** Data (`.yasnippet`, `.yas`), INI (`.flc`), PostScript (`.gsf`), Readmes (`FAQ`, `*.faq`)
+- **Support:** Ansible (*/roles/*/{defaults,vars,tests,meta}/*.yml, Data (`.yasnippet`, `.yas`), INI (`.flc`), PostScript (`.gsf`), Readmes (`FAQ`, `*.faq`)
 
 ### Changed
 - Increased minimum required Atom version to v1.25.0

--- a/config.cson
+++ b/config.cson
@@ -306,7 +306,8 @@ fileIcons:
 		priority: 2
 		match: [
 			[/(^|\.)ansible(\.ya?ml)?$/i, "dark-cyan", scope: /^source\.ansible([.-]advanced)?$/i]
-			[/([\\/])roles\1[^\\/]+\1(?:tasks|handlers)\1.*\.ya?ml$/i, "dark-cyan", matchPath: true]
+			[/([\\/])roles\1[^\\/]+\1(?:tasks|handlers|tests)\1.*\.ya?ml$/i, "dark-cyan", matchPath: true]
+			[/([\\/])roles\1[^\\/]+\1(?:defaults|vars|meta)\1.*\.ya?ml$/i, "light-cyan", matchPath: true]
 			[/([\\/])(?:group_vars|host_vars)\1.*\.ya?ml$/i, "dark-cyan", matchPath: true]
 		]
 


### PR DESCRIPTION
Related to #751 - I added support for Ansible icon on the rest of the role-folders (vars,defaults,meta,tests). They seemed a bit lonely without the nice Ansible icon 😄 

@brandonkal, I read you had some preferences regarding variable files vs. tasks and handlers, so feel free to criticize on the coloring here. Same goes for you, @Alhadis. 
This is a humble PR, so feel free to shoot me down if you guys don't like it. 