### PR TITLE
Update matching pattern for ESDoc

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -1536,7 +1536,7 @@ fileIcons:
 	ESDoc:
 		icon: "esdoc"
 		priority: 2
-		match: /^\.?esdoc\.json$/i
+		match: /^\.?esdoc\.js(on)?$/i
 		colour: "medium-red"
 
 	ESLint:


### PR DESCRIPTION
Both `.esdoc.json` and `.esdoc.js` are default file names for the ESDoc configuration file, as per the [official documentation](https://esdoc.org/manual/usage.html)