### PR TITLE
hardcode bin bash

### DIFF
--- a/lib/icons/icon-tables.js
+++ b/lib/icons/icon-tables.js
@@ -18,8 +18,8 @@ class IconTables{
 		const data = require("./.icondb.js");
 		this.directoryIcons = this.read(data[0]);
 		this.fileIcons      = this.read(data[1]);
-		this.binaryIcon     = this.matchName(".o");
-		this.executableIcon = this.matchInterpreter("bash");
+		this.binaryIcon     = new Icon(479, ...["binary-icon", ["medium-red", "medium-red"], /\.(?:[ls]?o|out)$|\.rpy[bc]$/i]);
+		this.executableIcon = new Icon(1512, ...["terminal-icon", ["medium-purple", "medium-purple"], /\.(?:sh|rc|bats|bash|tool|install|command)$/i,, false, /^(?:[bd]ash|a?sh|zsh|rc)$/, /\.shell$/i, /^(?:sh|shell|Shell-?Script|Bash)$/i]);
 	}
 	
 	


### PR DESCRIPTION
By hard coding these two icons you reduce the loading time a lot (about 30-40ms). You shouldn't search through thousands of icons just to extract two arrays.
# Before
![2020-05-07 00_41_08-Timecop — C__Users_yahyaaba_Documents_GitHub_JavaScript_file-icons — Atom](https://user-images.githubusercontent.com/16418197/81258571-91913f80-8ffb-11ea-8369-c6c27bb6c0b1.jpg)
![2020-05-07 00_41_02-Timecop — C__Users_yahyaaba_Documents_GitHub_JavaScript_file-icons — Atom](https://user-images.githubusercontent.com/16418197/81258581-9950e400-8ffb-11ea-9e72-4686b83fd84e.jpg)


# After
![2020-05-07 00_33_13-Timecop — C__Users_yahyaaba_Documents_GitHub_JavaScript_file-icons — Atom](https://user-images.githubusercontent.com/16418197/81258141-9ef9fa00-8ffa-11ea-985b-b7ef7e910c5e.jpg)
![2020-05-07 00_33_05-Timecop — C__Users_yahyaaba_Documents_GitHub_JavaScript_file-icons — Atom](https://user-images.githubusercontent.com/16418197/81258145-a02b2700-8ffa-11ea-9ad6-8d8d07d0be12.jpg)

Benchmark is done on top of #814 