### PR TITLE
Use Arch Linux instead of terminal icon for PKGBUILD files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [`daa9906`][] not applying to shell-script tests
 - Inconsistent icons for JavaScript tests with `.mjs` and `.cjs` extensions
+- PKGBUILD using Shell instead of using Arch Linux icon
 
 [`daa9906`]: https://github.com/file-icons/atom/commit/daa9906fb4a0627c996f70dae96d060fd273a34d
 

--- a/config.cson
+++ b/config.cson
@@ -5504,7 +5504,7 @@ fileIcons:
 				scope: "shell"
 				alias: /^(sh|shell|Shell-?Script|Bash)$/i
 				interpreter: /^([bd]ash|a?sh|zsh|rc)$/]
-			[/^(\.?bash(rc|[-_]?(profile|login|logout|history|prompt))|_osc|config|install-sh|PKGBUILD)$/i, "dark-purple"]
+			[/^(\.?bash(rc|[-_]?(profile|login|logout|history|prompt))|_osc|config|install-sh)$/i, "dark-purple"]
 			[/\.(ksh|mksh|pdksh)$/i, "dark-yellow"
 				scope: "ksh-shell"
 				interpreter: /^(ksh|mksh(-static)?|pdksh|lksh)$/i]

--- a/lib/icons/.icondb.js
+++ b/lib/icons/.icondb.js
@@ -1563,7 +1563,7 @@ module.exports = [
 ["graph-icon",["dark-blue","dark-blue"],/\.prn$/i],
 ["sf-icon",["light-orange","light-orange"],/\.sfproj$/i],
 ["terminal-icon",["medium-purple","medium-purple"],/\.(?:sh|rc|bats|bash|tool|install|command)$/i,,false,/^(?:[bd]ash|a?sh|zsh|rc)$/,/\.shell$/i,/^(?:sh|shell|Shell-?Script|Bash)$/i],
-["terminal-icon",["dark-purple","dark-purple"],/^(?:\.?bash(?:rc|[-_]?(?:profile|login|logout|history|prompt))|_osc|config|install-sh|PKGBUILD)$|\.profile$/i],
+["terminal-icon",["dark-purple","dark-purple"],/^(?:\.?bash(?:rc|[-_]?(?:profile|login|logout|history|prompt))|_osc|config|install-sh)$|\.profile$/i],
 ["terminal-icon",["dark-yellow","dark-yellow"],/\.(?:ksh|mksh|pdksh)$/i,,false,/^(?:ksh|mksh(?:-static)?|pdksh|lksh)$/i,/\.ksh-shell$/i],
 ["terminal-icon",["medium-yellow","dark-yellow"],/\.sh-session$/i,,false,,/\.shell-session$/i,/^(?:Bash|Shell|Sh)[-\s]*(?:Session|Console)$/i],
 ["terminal-icon",["medium-blue","medium-blue"],/\.zsh(?:-theme|_history)?$|^\.?(?:antigen|zpreztorc|zlogin|zlogout|zprofile|zshenv|zshrc)$|\.tmux$/i],


### PR DESCRIPTION
When the Arch Linux icon was added #382, a matching for files named `PKGBUILD` was added for the Arch Linux icon, but it wasn’t removed for the Shell icon. This PR fixes this.