### PR TITLE
Add support for poetry.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unpublished]: https://github.com/file-icons/atom/compare/v2.1.42...HEAD
+### Added
+- **Support**: Poetry (`poetry.lock`)
 
 
 [v2.1.42] - 2020-07-25

--- a/config.cson
+++ b/config.cson
@@ -1527,6 +1527,7 @@ fileIcons:
 		match: [
 			[/^python-?config\.json$/i, "dark-blue"]
 			[/^pyproject\.toml$/i, "dark-blue"]
+			[/^poetry\.lock$/i, "dark-blue"]
 		]
 
 	"Config, React":

--- a/lib/icons/.icondb.js
+++ b/lib/icons/.icondb.js
@@ -375,7 +375,7 @@ module.exports = [
 ["config-hs-icon",["medium-purple","dark-purple"],/^haskellconfig\.json$/i,1.5],
 ["config-js-icon",["medium-yellow","dark-yellow"],/^(?:jsconfig(?:\..+)?|\.?eshost(?:-config)?)\.json$/i,1.5],
 ["config-perl-icon",["medium-blue","medium-blue"],/^perl[56]?-?config\.json$/i,1.5],
-["config-python-icon",["dark-blue","dark-blue"],/^python-?config\.json$|^pyproject\.toml$/i,1.5],
+["config-python-icon",["dark-blue","dark-blue"],/^python-?config\.json$|^pyproject\.toml$|^poetry\.lock$/i,1.5],
 ["config-react-icon",["medium-blue","dark-blue"],/^jsxconfig\.json$/i,1.5],
 ["config-ruby-icon",["medium-red","dark-red"],/^rubyconfig\.json$/i,1.5],
 ["config-rust-icon",["medium-maroon","medium-maroon"],/^rustconfig\.json$/i,1.5],


### PR DESCRIPTION
Thanks for this package!
I added support for `poetry.lock`, a lock file for Poetry, a dependency manager for Python. It uses the `config-python` icon.