### PR TITLE
Check if the same file is created before removing from FileSystem

### DIFF
--- a/lib/service/icon-service.js
+++ b/lib/service/icon-service.js
@@ -18,19 +18,12 @@ class IconService{
 			// #693: Notify `FileSystem` when files are deleted
 			atom.project.onDidChangeFiles(events => {
 				for(const {action, path} of events){
-					if("deleted" === action && FileSystem.paths.has(path)){
-						if(
-							events.every(
-								event =>
-									"created" !== event.action ||
-									path !== event.path
-							)
-						) {
-							const resource = FileSystem.get(path);
-							if(resource)
-								resource.destroy();
-							Storage.deletePath(path);
-						}
+					if("deleted" === action && FileSystem.paths.has(path)
+					&& events.every(e => "created" !== e.action || path !== e.path)){
+						const resource = FileSystem.get(path);
+						if(resource)
+							resource.destroy();
+						Storage.deletePath(path);
 					}
 				}
 			}),

--- a/lib/service/icon-service.js
+++ b/lib/service/icon-service.js
@@ -19,10 +19,18 @@ class IconService{
 			atom.project.onDidChangeFiles(events => {
 				for(const {action, path} of events){
 					if("deleted" === action && FileSystem.paths.has(path)){
-						const resource = FileSystem.get(path);
-						if(resource)
-							resource.destroy();
-						Storage.deletePath(path);
+						if(
+							events.every(
+								event =>
+									"created" !== event.action ||
+									path !== event.path
+							)
+						) {
+							const resource = FileSystem.get(path);
+							if(resource)
+								resource.destroy();
+							Storage.deletePath(path);
+						}
 					}
 				}
 			}),


### PR DESCRIPTION
Fixes issues mentioned in #693 

Summary: Whenever a file is "deleted" & "created" instantaneously, which can happen when formatters are run or git modifies the file, then the resource for the file gets destroyed and never gets created again. This adds a check to see if the file is created in the same call.