### PR TITLE
Add '.yamllint.yaml' and '.yamllint.yml' matchs

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -7167,7 +7167,7 @@ fileIcons:
 
 	YAMLLint:
 		icon: "yamllint"
-		match: /^\.yamllint$/i
+		match: /^\.yamllint(\.ya?ml)?$/i
 		colour: "medium-green"
 		priority: 2
 


### PR DESCRIPTION
yamllint uses [3 possible configuration file names](https://yamllint.readthedocs.io/en/stable/configuration.html#configuration). This pull adds next 2:

- `.yamllint.yaml`
- `.yamllint.yml`