### PR TITLE
Add support for Pipenv files

### DIFF
--- a/lib/icons/.icondb.js
+++ b/lib/icons/.icondb.js
@@ -415,7 +415,7 @@ module.exports = [
 ["config-hs-icon",["medium-purple","dark-purple"],/^haskellconfig\.json$/i,1.5],
 ["config-js-icon",["medium-yellow","dark-yellow"],/\.js(?:beautify|cs|hint)rc$|^(?:jsconfig(?:\..+)?|\.?eshost(?:-config)?)\.json$/i,1.5],
 ["config-perl-icon",["medium-blue","medium-blue"],/^perl[56]?-?config\.json$/i,1.5],
-["config-python-icon",["dark-blue","dark-blue"],/^python-?config\.json$|^pyproject\.toml$|^poetry\.lock$|^\.coveragerc$|^MANIFEST\.in$|\.python-version$|\.flake8$/i,1.5],
+["config-python-icon",["dark-blue","dark-blue"],/^python-?config\.json$|^pyproject\.toml$|^Pipfile?(\.lock)$|^poetry\.lock$|^\.coveragerc$|^MANIFEST\.in$|\.python-version$|\.flake8$/i,1.5],
 ["config-react-icon",["medium-blue","dark-blue"],/^jsxconfig\.json$/i,1.5],
 ["config-ruby-icon",["medium-red","dark-red"],/^rubyconfig\.json$|\.(?:autotest|cross_rubies|gemtest|hoerc|kick|simplecov|yardopts)$/i,1.5],
 ["config-rust-icon",["medium-maroon","medium-maroon"],/^rustconfig\.json$/i,1.5],


### PR DESCRIPTION
Python icon should be shown to Pipfile and Pipfile.lock when using Pipenv to manage Python workspace.

Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>