### PR TITLE
Ignore `pnpm-lock.yaml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ node_modules
 /test.mjs
 /test.js
 package-lock.json
+pnpm-lock.yaml
 /styles/ui-variables.less


### PR DESCRIPTION
At least judging by the `.gitignore`, it looks like you want to let potential contributors choose their own package manager. With `pnpm` gaining popularity, I figured that you would want this ignored, too.
