### PR TITLE
Support ESlint 9 config files

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -2344,7 +2344,7 @@ fileIcons:
 		match: [
 			[/\.eslint(cache|ignore)$/i, "medium-purple"]
 			[/\.eslintrc($|\.)/i, "light-purple"]
-			[/^eslint\.config\.js$/i, "light-purple"]
+			[/^eslint\.config\.(m|c|)[jt]s$/i, "light-purple"]
 		]
 
 	ExtJS:


### PR DESCRIPTION
update regex to `eslint\.config\.(m|c|)[jt]s` to match all js/ts files options:

from [https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file)
> eslint.config.js
eslint.config.mjs
eslint.config.cjs
eslint.config.ts
eslint.config.mts
eslint.config.cts